### PR TITLE
Add message reactions to user

### DIFF
--- a/examples/ping.py
+++ b/examples/ping.py
@@ -1,13 +1,12 @@
 from matrix.bot import Bot, Context
 
-
-bot = Bot('examples/config.yaml')
+bot = Bot("examples/config.yaml")
 
 
 @bot.command("ping")
 async def ping(ctx: Context):
     print(f"{ctx.sender} invoked {ctx.body} in room {ctx.room_name}.")
-    await ctx.send("Pong!")
+    await ctx.reply("Pong!")
 
 
 bot.start()

--- a/examples/reaction.py
+++ b/examples/reaction.py
@@ -4,7 +4,7 @@ bot = Bot("examples/config.yaml")
 
 
 @bot.event
-async def on_message_react(room, event):
+async def on_message(room, event):
     """
     This function listens for new messages in a room and reacts based
     on the message content.
@@ -22,7 +22,7 @@ async def on_message_react(room, event):
 
 
 @bot.event
-async def on_member_react(room, event):
+async def on_react(room, event):
     """
     This function listens for new member reaction to messages in a room,
     and reacts based on the reaction emoji.

--- a/examples/reaction.py
+++ b/examples/reaction.py
@@ -5,6 +5,10 @@ bot = Bot("examples/config.yaml")
 
 @bot.event
 async def on_message_react(room, event):
+    """
+    This function listens for new messages in a room and reacts based
+    on the message content.
+    """
     room = bot.get_room(room.room_id)
     if event.body.lower().startswith("thanks"):
         await room.send(event=event, key="🙏")
@@ -13,9 +17,16 @@ async def on_message_react(room, event):
         # Can also react with a text message instead of emoji
         await room.send(event=event, key="hi")
 
+    if event.body.lower().startswith("❤️"):
+        await room.send(event=event, message="❤️")
+
 
 @bot.event
 async def on_member_react(room, event):
+    """
+    This function listens for new member reaction to messages in a room,
+    and reacts based on the reaction emoji.
+    """
     room = bot.get_room(room.room_id)
 
     emoji = event.key
@@ -23,6 +34,9 @@ async def on_member_react(room, event):
 
     if emoji == "🙏":
         await room.send(event=event_id, key="❤️")
+
+    if emoji == "❤️":
+        await room.send(message="❤️")
 
 
 bot.start()

--- a/examples/reaction.py
+++ b/examples/reaction.py
@@ -1,10 +1,9 @@
 from matrix.bot import Bot
-from nio import RoomMessageText
 
 bot = Bot("examples/config.yaml")
 
 
-@bot.event(event_spec=RoomMessageText)
+@bot.event(event_spec="on_react")
 async def react_event(room, event):
     room = bot.get_room(room.room_id)
     if event.body.lower().startswith("thanks"):

--- a/examples/reaction.py
+++ b/examples/reaction.py
@@ -3,8 +3,8 @@ from matrix.bot import Bot
 bot = Bot("examples/config.yaml")
 
 
-@bot.event(event_spec="on_react")
-async def react_event(room, event):
+@bot.event
+async def on_message_react(room, event):
     room = bot.get_room(room.room_id)
     if event.body.lower().startswith("thanks"):
         await room.send(event=event, key="🙏")
@@ -12,6 +12,17 @@ async def react_event(room, event):
     if event.body.lower().startswith("hello"):
         # Can also react with a text message instead of emoji
         await room.send(event=event, key="hi")
+
+
+@bot.event
+async def on_member_react(room, event):
+    room = bot.get_room(room.room_id)
+
+    emoji = event.key
+    event_id = event.source["content"]["m.relates_to"]["event_id"]
+
+    if emoji == "🙏":
+        await room.send(event=event_id, key="❤️")
 
 
 bot.start()

--- a/examples/reaction.py
+++ b/examples/reaction.py
@@ -1,0 +1,18 @@
+from matrix.bot import Bot
+from nio import RoomMessageText
+
+bot = Bot("examples/config.yaml")
+
+
+@bot.event(event_spec=RoomMessageText)
+async def react_event(room, event):
+    room = bot.get_room(room.room_id)
+    if event.body.lower().startswith("thanks"):
+        await room.send(event=event, key="🙏")
+
+    if event.body.lower().startswith("hello"):
+        # Can also react with a text message instead of emoji
+        await room.send(event=event, key="hi")
+
+
+bot.start()

--- a/matrix/bot.py
+++ b/matrix/bot.py
@@ -50,6 +50,7 @@ class Bot:
     EVENT_MAP: Dict[str, Type[Event]] = {
         "on_typing":        TypingNoticeEvent,
         "on_message":       RoomMessageText,
+        "on_react":         RoomMessageText,
         "on_member_join":   RoomMemberEvent,
         "on_member_leave":  RoomMemberEvent,
         "on_member_invite": RoomMemberEvent,

--- a/matrix/bot.py
+++ b/matrix/bot.py
@@ -51,8 +51,7 @@ class Bot:
     EVENT_MAP: Dict[str, Type[Event]] = {
         "on_typing":        TypingNoticeEvent,
         "on_message":       RoomMessageText,
-        "on_message_react": RoomMessageText,
-        "on_member_react":  ReactionEvent,
+        "on_react":         ReactionEvent,
         "on_member_join":   RoomMemberEvent,
         "on_member_leave":  RoomMemberEvent,
         "on_member_invite": RoomMemberEvent,

--- a/matrix/bot.py
+++ b/matrix/bot.py
@@ -20,6 +20,7 @@ from nio import (
     RoomMessageText,
     RoomMemberEvent,
     TypingNoticeEvent,
+    ReactionEvent,
 )
 from matrix.room import Room
 from matrix.config import Config
@@ -50,7 +51,8 @@ class Bot:
     EVENT_MAP: Dict[str, Type[Event]] = {
         "on_typing":        TypingNoticeEvent,
         "on_message":       RoomMessageText,
-        "on_react":         RoomMessageText,
+        "on_message_react": RoomMessageText,
+        "on_member_react":  ReactionEvent,
         "on_member_join":   RoomMemberEvent,
         "on_member_leave":  RoomMemberEvent,
         "on_member_invite": RoomMemberEvent,

--- a/matrix/message.py
+++ b/matrix/message.py
@@ -1,6 +1,7 @@
 from matrix.errors import MatrixError
 import markdown
 from typing import Dict, Optional
+from nio import Event
 
 
 class Message:
@@ -47,7 +48,14 @@ class Message:
         except Exception as e:
             raise MatrixError(f"Failed to send message: {e}")
 
-    def _make_content(self, body: str, html: Optional[bool]) -> Dict:
+    def _make_content(
+        self,
+        body: str,
+        html: Optional[bool] = None,
+        reaction: Optional[bool] = None,
+        event_id: Optional[str] = None,
+        key: Optional[str] = None,
+    ) -> Dict:
         """
         Create the content dictionary for a message.
 
@@ -55,6 +63,12 @@ class Message:
         :type body: str
         :param html: Wheter to format the message as HTML.
         :type html: bool
+        :param reaction: Wheter to format the context with a reaction event.
+        :type reaction: bool
+        :param event_id: The ID of the event to react to.
+        :type event_id: str
+        :param key: The reaction to the message.
+        :type key: Optional[str]
 
         :return: The content of the dictionary.
         """
@@ -68,10 +82,18 @@ class Message:
             base["format"] = self.MATRIX_CUSTOM_HTML
             base["formatted_body"] = html_body
 
+        if reaction:
+            base["m.relates_to"] = {
+                "event_id": event_id,
+                "key": key,
+                "rel_type": "m.annotation",
+            }
+
         return base
 
     async def send(
-        self, room_id: str,
+        self,
+        room_id: str,
         message: str,
         format_markdown: Optional[bool] = True
     ) -> None:
@@ -88,5 +110,32 @@ class Message:
         """
         await self._send_to_room(
             room_id=room_id,
-            content=self._make_content(message, format_markdown),
+            content=self._make_content(body=message, html=format_markdown),
+        )
+
+    async def send_reaction(
+        self, room_id: str, event: Event, key: str
+    ) -> None:
+        """
+        Send a reaction to a message from a user in a Matrix room.
+
+        :param room_id: The ID of the room to send the message to.
+        :type room_id: str
+        :param event: The event object to react to.
+        :type event: Event
+        :param key: The reaction to the message.
+        :type key: str
+        """
+        if isinstance(event, Event):
+            event_id = event.event_id
+        else:
+            event_id = event
+            print("hi")
+
+        await self._send_to_room(
+            room_id=room_id,
+            content=self._make_content(
+                body="", event_id=event_id, key=key, reaction=True
+            ),
+            message_type="m.reaction",
         )

--- a/matrix/message.py
+++ b/matrix/message.py
@@ -130,7 +130,6 @@ class Message:
             event_id = event.event_id
         else:
             event_id = event
-            print("hi")
 
         await self._send_to_room(
             room_id=room_id,

--- a/matrix/message.py
+++ b/matrix/message.py
@@ -50,7 +50,7 @@ class Message:
 
     def _make_content(
         self,
-        body: str,
+        body: Optional[str] = "",
         html: Optional[bool] = None,
         reaction: Optional[bool] = None,
         event_id: Optional[str] = None,
@@ -94,7 +94,7 @@ class Message:
     async def send(
         self,
         room_id: str,
-        message: str,
+        message: Optional[str],
         format_markdown: Optional[bool] = True
     ) -> None:
         """
@@ -134,7 +134,7 @@ class Message:
         await self._send_to_room(
             room_id=room_id,
             content=self._make_content(
-                body="", event_id=event_id, key=key, reaction=True
+                event_id=event_id, key=key, reaction=True
             ),
             message_type="m.reaction",
         )

--- a/matrix/message.py
+++ b/matrix/message.py
@@ -62,11 +62,11 @@ class Message:
         :param body: The body of the message.
         :type body: str
         :param html: Wheter to format the message as HTML.
-        :type html: bool
+        :type html: Optional[bool]
         :param reaction: Wheter to format the context with a reaction event.
-        :type reaction: bool
+        :type reaction: Optional[bool]
         :param event_id: The ID of the event to react to.
-        :type event_id: str
+        :type event_id: Optional[str]
         :param key: The reaction to the message.
         :type key: Optional[str]
 
@@ -106,7 +106,7 @@ class Message:
         :type message: str
         :param format_markdown: Whether to format the message as Markdown
             (default to True).
-        :type format_markdown: bool
+        :type format_markdown: Optional[bool]
         """
         await self._send_to_room(
             room_id=room_id,

--- a/matrix/message.py
+++ b/matrix/message.py
@@ -50,7 +50,7 @@ class Message:
 
     def _make_content(
         self,
-        body: Optional[str] = "",
+        body: str = "",
         html: Optional[bool] = None,
         reaction: Optional[bool] = None,
         event_id: Optional[str] = None,
@@ -94,7 +94,7 @@ class Message:
     async def send(
         self,
         room_id: str,
-        message: Optional[str],
+        message: str,
         format_markdown: Optional[bool] = True
     ) -> None:
         """

--- a/matrix/room.py
+++ b/matrix/room.py
@@ -43,11 +43,11 @@ class Room:
         :raises MatrixError: If sending the message fails.
         """
         try:
-            message = Message(self.bot)
+            msg = Message(self.bot)
             if key:
-                await message.send_reaction(self.room_id, event, key)
+                await msg.send_reaction(self.room_id, event, key)
             else:
-                await message.send(self.room_id, message, markdown)
+                await msg.send(self.room_id, message, markdown)
         except Exception as e:
             raise MatrixError(f"Failed to send message: {e}")
 

--- a/matrix/room.py
+++ b/matrix/room.py
@@ -1,6 +1,7 @@
 from matrix.errors import MatrixError
 from matrix.message import Message
 from typing import TYPE_CHECKING, Optional
+from nio import Event
 
 if TYPE_CHECKING:
     from matrix.bot import Bot  # pragma: no cover
@@ -21,23 +22,32 @@ class Room:
         self.bot = bot
 
     async def send(
-            self,
-            message: str,
-            markdown: Optional[bool] = True
+        self,
+        message: Optional[str] = None,
+        markdown: Optional[bool] = True,
+        event: Optional[Event] = None,
+        key: Optional[str] = None,
     ) -> None:
         """
         Send a message to the room.
 
         :param message: The message to send.
-        :type message: str
+        :type message: Optional[str]
         :param markdown: Whether to format the message as Markdown.
-        :type markdown: bool
+        :type markdown: Optional[bool]
+        :param event: An event object to react to.
+        :type event: Optional[Event]
+        :param key: The reaction to the message.
+        :type key: Optional[str]
 
         :raises MatrixError: If sending the message fails.
         """
         try:
             room = Message(self.bot)
-            await room.send(self.room_id, message, markdown)
+            if key:
+                await room.send_reaction(self.room_id, event, key)
+            else:
+                await room.send(self.room_id, message, markdown)
         except Exception as e:
             raise MatrixError(f"Failed to send message: {e}")
 

--- a/matrix/room.py
+++ b/matrix/room.py
@@ -32,7 +32,7 @@ class Room:
         Send a message to the room.
 
         :param message: The message to send.
-        :type message: Optional[str]
+        :type message: str
         :param markdown: Whether to format the message as Markdown.
         :type markdown: Optional[bool]
         :param event: An event object to react to.
@@ -79,7 +79,7 @@ class Room:
         :param user_id: The ID of the user to ban of the room.
         :type user_id: str
         :param reason: The reason to ban the user.
-        :type reason: str
+        :type reason: Optional[str]
 
         :raises MatrixError: If banning the user fails.
         """
@@ -122,7 +122,7 @@ class Room:
         :param user_id: The ID of the user to kick of the room.
         :type user_id: str
         :param reason: The reason to kick the user.
-        :type reason: str
+        :type reason: Optional[str]
 
         :raises MatrixError: If kicking the user fails.
         """

--- a/matrix/room.py
+++ b/matrix/room.py
@@ -23,7 +23,7 @@ class Room:
 
     async def send(
         self,
-        message: Optional[str] = None,
+        message: str = "",
         markdown: Optional[bool] = True,
         event: Optional[Event] = None,
         key: Optional[str] = None,

--- a/matrix/room.py
+++ b/matrix/room.py
@@ -43,11 +43,11 @@ class Room:
         :raises MatrixError: If sending the message fails.
         """
         try:
-            room = Message(self.bot)
+            message = Message(self.bot)
             if key:
-                await room.send_reaction(self.room_id, event, key)
+                await message.send_reaction(self.room_id, event, key)
             else:
-                await room.send(self.room_id, message, markdown)
+                await message.send(self.room_id, message, markdown)
         except Exception as e:
             raise MatrixError(f"Failed to send message: {e}")
 


### PR DESCRIPTION
### Description
Added support for message reactions and member reactions in the Message class, refactored the send method in the Room class to accommodate reactions, and improved parameter handling. Include examples for reaction events and add unit tests for the new functionality. Modify the ping command to use the reply method instead of the send method.

This implementation enables bots to respond when a user sends a specific keyword or sentence, as well as when a member reacts to an existing message with an emoji. By using `@bot.event`, you can now have `on_message_react()` and `on_member_react()`, and the boost will listen for incoming messages and member reactions.

### TO-DO
- [x] Implementation
- [x] Unit tests