### PR TITLE
Add global check functionality to Bot class

### DIFF
--- a/matrix/bot.py
+++ b/matrix/bot.py
@@ -270,11 +270,11 @@ class Bot:
         """Parse and execute commands"""
         ctx = await self._build_context(room, event)
 
-        for check in self.checks:
-            if not await check(ctx):
-                raise CheckError(None, check)
-
         if ctx.command:
+            for check in self.checks:
+                if not await check(ctx):
+                    raise CheckError(ctx.command, check)
+
             await ctx.command(ctx)
 
     async def _build_context(self, room: MatrixRoom, event: Event):

--- a/matrix/errors.py
+++ b/matrix/errors.py
@@ -23,7 +23,12 @@ class MissingArgumentError(CommandError):
 
 class CheckError(CommandError):
     def __init__(self, cmd, check):
-        super().__init__(f"'{check.__name__}' has failed for '{cmd.name}'!")
+        if cmd is None:
+            cmd_name = "global check"
+        else:
+            cmd_name = cmd.name
+
+        super().__init__(f"'{check.__name__}' has failed for '{cmd_name}'!")
 
 
 class ConfigError(MatrixError):

--- a/matrix/errors.py
+++ b/matrix/errors.py
@@ -23,12 +23,7 @@ class MissingArgumentError(CommandError):
 
 class CheckError(CommandError):
     def __init__(self, cmd, check):
-        if cmd is None:
-            cmd_name = "global check"
-        else:
-            cmd_name = cmd.name
-
-        super().__init__(f"'{check.__name__}' has failed for '{cmd_name}'!")
+        super().__init__(f"'{check.__name__}' has failed for '{cmd.name}'!")
 
 
 class ConfigError(MatrixError):

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -6,6 +6,7 @@ from nio import MatrixRoom, RoomMessageText
 from matrix.bot import Bot
 from matrix.config import Config
 from matrix.errors import (
+    CheckError,
     CommandNotFoundError,
     AlreadyRegisteredError,
     ConfigError
@@ -285,7 +286,8 @@ async def test_bot_does_not_execute_when_global_check_fails(bot, event):
         mock_ctx.command = bot.commands["greet"]
         MockContext.return_value = mock_ctx
 
-        await bot._process_commands(room, event)
+        with pytest.raises(CheckError):
+            await bot._process_commands(room, event)
 
     assert not called, "Expected command handler not to be called"
 


### PR DESCRIPTION
Adds a global check functionality to the Bot.

Checks are run (and raised if needed) every time commands are executed.