### PR TITLE
Improved Fallback of Error Handler

### DIFF
--- a/matrix/bot.py
+++ b/matrix/bot.py
@@ -184,10 +184,6 @@ class Bot(Registry):
             await handler(error)
             return
 
-        if self._fallback_error_handler:
-            await self._fallback_error_handler(error)
-            return
-
         await self._dispatch("on_error", error)
 
     async def on_command(self, _ctx: Context) -> None:

--- a/matrix/registry.py
+++ b/matrix/registry.py
@@ -65,7 +65,6 @@ class Registry:
 
         self._event_handlers: Dict[Type[Event], List[Callback]] = defaultdict(list)
         self._hook_handlers: Dict[str, List[Callback]] = defaultdict(list)
-        self._fallback_error_handler: Optional[ErrorCallback] = None
         self._error_handlers: Dict[type[Exception], ErrorCallback] = {}
         self._command_error_handlers: Dict[type[Exception], CommandErrorCallback] = {}
 
@@ -378,14 +377,15 @@ class Registry:
         ```
         """
 
+        if not exception:
+            exception = Exception
+
         def wrapper(func: ErrorCallback) -> ErrorCallback:
             if not inspect.iscoroutinefunction(func):
                 raise TypeError("Error handlers must be coroutines")
 
-            if exception:
-                self._error_handlers[exception] = func
-            else:
-                self._fallback_error_handler = func
+            self._error_handlers[exception] = func
+
             logger.debug(
                 "registered error handler '%s' on %s",
                 func.__name__,

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -206,9 +206,7 @@ async def test_on_error_calls_fallback_handler(bot):
         nonlocal called
         called = True
 
-    await bot._fallback_error_handler(Exception("test error"))
-    await bot.on_error(Exception("test error"))
-
+    await bot._on_error(Exception("test error"))
     assert called, "Fallback error handler was not called"
 
 

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -297,16 +297,6 @@ def test_register_error_handler_with_exception_type__expect_handler_in_dict(
     assert registry._error_handlers[ValueError] is on_value_error
 
 
-def test_register_generic_error_handler__expect_fallback_error_handler_set(
-    registry: Registry,
-):
-    @registry.error()
-    async def on_any_error(error):
-        pass
-
-    assert registry._fallback_error_handler is on_any_error
-
-
 def test_register_error_handler_with_non_coroutine__expect_type_error(
     registry: Registry,
 ):


### PR DESCRIPTION
This PR Improves how fallback of error handlers are set by setting Exception directly instead of using a fallback dictionary. 