### PR TITLE
Add a `py.typed`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,9 @@ dev = [
 packages = ["matrix"]
 license-files = []
 
+[tool.setuptools.package-data]
+matrix = ["py.typed"]
+
 [tool.setuptools_scm]
 write_to = "matrix/_version.py"
 


### PR DESCRIPTION
Add a `py.typed` marker file so mypy and other type checkers recognize this package as typed.