### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ Send `!ping` in any room the bot is in, it will reply `Pong!`.
 
 ## Where to go next
 
-- [**Guides**](https://matrixpy.code-society.xyz/guides/introduction/) — step-by-step tutorials covering commands,
+- [**Guides**](https://matrixpy.codesociety.xyz/guides/introduction/) — step-by-step tutorials covering commands,
   events, checks, extensions, and more
-- [**Reference**](https://matrixpy.code-society.xyz/reference/bot/) — complete API documentation for every class and
+- [**Reference**](https://matrixpy.codesociety.xyz/reference/bot/) — complete API documentation for every class and
   function
 - [**Examples**](https://matrixpy.codesociety.xyz/examples/) — ready-to-run example bots
   demonstrating common patterns


### PR DESCRIPTION
Fix small typo in readme.  -> code-society.xyz instead of codesociety.xyz

<img width="1080" height="757" alt="Capture d’écran du 2026-04-19 19-37-39" src="https://github.com/user-attachments/assets/95786a69-ac27-4b16-ac6c-a026a3152924" />
