### PR TITLE
Deploy docs on release instead of push to main

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,9 +1,8 @@
 name: Deploy Docs
 
 on:
-  push:
-    branches:
-      - main
+  release:
+    types: [ published ]
 
 permissions:
   contents: read
@@ -28,7 +27,7 @@ jobs:
         run: pip install .[doc]
 
       - name: Build docs
-        run: mkdocs build --config-file docs/mkdocs.yml
+        run: cd docs && mkdocs build
 
       - uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
Updates the docs deployment workflow to trigger on published releases rather than every push to main, and changed the mkdocs build command by running it from within the docs/ directory to fix examples not showing up.