### PR TITLE
feat: add get_members method to Room

### DIFF
--- a/matrix/room.py
+++ b/matrix/room.py
@@ -465,15 +465,15 @@ class Room:
     async def get_members(self) -> list[str]:
         """Fetch the list of user IDs currently joined to the room.
 
-                This queries the Matrix server directly for the current membership,
-                which may include members not yet reflected in local room state.
+        This queries the Matrix server directly for the current membership,
+        which may include members not yet reflected in local room state.
 
-                ## Example
+        ## Example
 
         ```python
-                members = await room.get_members()
-                print(f"{len(members)} members: {', '.join(members)}")
-            ```
+        members = await room.get_members()
+        print(f"{len(members)} members: {', '.join(members)}")
+        ```
         """
         try:
             response = await self.client.joined_members(self.room_id)

--- a/matrix/room.py
+++ b/matrix/room.py
@@ -461,3 +461,22 @@ class Room:
             )
         except Exception as e:
             raise MatrixError(f"Failed to kick user: {e}")
+
+    async def get_members(self) -> list[str]:
+        """Fetch the list of user IDs currently joined to the room.
+
+                This queries the Matrix server directly for the current membership,
+                which may include members not yet reflected in local room state.
+
+                ## Example
+
+        ```python
+                members = await room.get_members()
+                print(f"{len(members)} members: {', '.join(members)}")
+        ```
+        """
+        try:
+            response = await self.client.joined_members(self.room_id)
+            return [member.user_id for member in response.members]
+        except Exception as e:
+            raise MatrixError(f"Failed to get members: {e}")

--- a/matrix/room.py
+++ b/matrix/room.py
@@ -473,7 +473,7 @@ class Room:
         ```python
                 members = await room.get_members()
                 print(f"{len(members)} members: {', '.join(members)}")
-        ```
+            ```
         """
         try:
             response = await self.client.joined_members(self.room_id)

--- a/tests/test_room.py
+++ b/tests/test_room.py
@@ -368,6 +368,34 @@ async def test_kick_user_with_error__expect_matrix_error(room, client):
         await room.kick_user("@troublemaker:example.com")
 
 
+# GET MEMBERS
+
+
+@pytest.mark.asyncio
+async def test_get_members__expect_list_of_user_ids(room, client):
+    member1 = Mock()
+    member1.user_id = "@alice:example.com"
+    member2 = Mock()
+    member2.user_id = "@bob:example.com"
+
+    response = Mock()
+    response.members = [member1, member2]
+    client.joined_members = AsyncMock(return_value=response)
+
+    result = await room.get_members()
+
+    client.joined_members.assert_awaited_once_with("!room:example.com")
+    assert result == ["@alice:example.com", "@bob:example.com"]
+
+
+@pytest.mark.asyncio
+async def test_get_members_with_error__expect_matrix_error(room, client):
+    client.joined_members = AsyncMock(side_effect=Exception("Network error"))
+
+    with pytest.raises(MatrixError, match="Failed to get members"):
+        await room.get_members()
+
+
 def test_room_properties__expect_correct_delegation_to_matrix_room(room, matrix_room):
     assert room.room_id == "!room:example.com"
     assert room.name == "Test Room"


### PR DESCRIPTION
Adds a `get_members` method to the `Room` class that fetches the list of currently joined user IDs by querying the Matrix server directly via `AsyncClient.joined_members`.

Closes #70