### PR TITLE
feat: add reason parameter to Message.delete()

### DIFF
--- a/matrix/message.py
+++ b/matrix/message.py
@@ -149,8 +149,10 @@ class Message:
         except Exception as e:
             raise MatrixError(f"Failed to edit message: {e}")
 
-    async def delete(self) -> None:
+    async def delete(self, reason: str | None = None) -> None:
         """Removes the message content from the room. This action cannot be undone.
+
+        Optionally provide a reason that will be visible to room moderators.
 
         ## Example
 
@@ -159,12 +161,16 @@ class Message:
         async def oops(ctx: Context):
             msg = await ctx.reply("Secret info!")
             await msg.delete()
+
+        # Delete with a reason
+        await message.delete(reason="Violated room rules")
         ```
         """
         try:
             await self.client.room_redact(
                 room_id=self.room.room_id,
                 event_id=self.event_id,
+                reason=reason,
             )
         except Exception as e:
             raise MatrixError(f"Failed to delete message: {e}")

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -121,7 +121,20 @@ async def test_delete__expect_message_redacted(message, client):
     await message.delete()
 
     client.room_redact.assert_awaited_once_with(
-        room_id="!room:example.com", event_id="$event123"
+        room_id="!room:example.com", event_id="$event123", reason=None
+    )
+
+
+@pytest.mark.asyncio
+async def test_delete_with_reason__expect_reason_passed(message, client):
+    client.room_redact = AsyncMock()
+
+    await message.delete(reason="Violated room rules")
+
+    client.room_redact.assert_awaited_once_with(
+        room_id="!room:example.com",
+        event_id="$event123",
+        reason="Violated room rules",
     )
 
 


### PR DESCRIPTION
Closes #76

Added optional \eason\ parameter to \Message.delete()\. Passes it through to \client.room_redact()\ which already supports it. Includes updated and new unit tests.