### PR TITLE
feat: add Room.mark_as_read() method

### DIFF
--- a/matrix/room.py
+++ b/matrix/room.py
@@ -379,6 +379,29 @@ class Room:
             client=self.client,
         )
 
+    async def mark_as_read(self, event_id: str) -> None:
+        """Send a read receipt for the given event.
+
+        Signals to other clients that the bot has read up to this event. Useful
+        for bots that process messages silently without sending a reply.
+
+        ## Example
+
+        ```python
+        @bot.event
+        async def on_message(room: Room, event: Event):
+            await room.mark_as_read(event.event_id)
+        ```
+        """
+        try:
+            await self.client.room_read_markers(
+                room_id=self.room_id,
+                fully_read_event=event_id,
+                read_event=event_id,
+            )
+        except Exception as e:
+            raise MatrixError(f"Failed to mark as read: {e}")
+
     async def invite_user(self, user_id: str) -> None:
         """Invite a user to the room.
 

--- a/tests/test_room.py
+++ b/tests/test_room.py
@@ -260,6 +260,30 @@ async def test_fetch_message_with_error__expect_matrix_error(room, client):
         await room.fetch_message("$event123")
 
 
+# MARK AS READ
+
+
+@pytest.mark.asyncio
+async def test_mark_as_read__expect_read_markers_sent(room, client):
+    client.room_read_markers = AsyncMock()
+
+    await room.mark_as_read("$event123")
+
+    client.room_read_markers.assert_awaited_once_with(
+        room_id="!room:example.com",
+        fully_read_event="$event123",
+        read_event="$event123",
+    )
+
+
+@pytest.mark.asyncio
+async def test_mark_as_read_with_error__expect_matrix_error(room, client):
+    client.room_read_markers = AsyncMock(side_effect=Exception("Network error"))
+
+    with pytest.raises(MatrixError, match="Failed to mark as read"):
+        await room.mark_as_read("$event123")
+
+
 # INVITE
 
 


### PR DESCRIPTION
Closes #77

Added \Room.mark_as_read(event_id)\ so bots can send read receipts without replying. Sets both \ully_read\ and \ead\ markers via \client.room_read_markers()\. Includes unit tests for success and error cases.