### PR TITLE
feat: add Room.set_name() and Room.set_topic() methods

### DIFF
--- a/matrix/room.py
+++ b/matrix/room.py
@@ -345,6 +345,42 @@ class Room:
         except Exception as e:
             raise MatrixError(f"Failed to send message: {e}")
 
+    async def set_name(self, name: str) -> None:
+        """Set the room's display name.
+
+        ## Example
+
+        ```python
+        await room.set_name("General")
+        ```
+        """
+        try:
+            await self.client.room_put_state(
+                room_id=self.room_id,
+                event_type="m.room.name",
+                content={"name": name},
+            )
+        except Exception as e:
+            raise MatrixError(f"Failed to set room name: {e}")
+
+    async def set_topic(self, topic: str) -> None:
+        """Set the room's topic.
+
+        ## Example
+
+        ```python
+        await room.set_topic("Last updated: 13:00 UTC")
+        ```
+        """
+        try:
+            await self.client.room_put_state(
+                room_id=self.room_id,
+                event_type="m.room.topic",
+                content={"topic": topic},
+            )
+        except Exception as e:
+            raise MatrixError(f"Failed to set room topic: {e}")
+
     async def fetch_event(self, event_id: str) -> Event:
         """Fetch a Matrix event by its ID.
 

--- a/tests/test_room.py
+++ b/tests/test_room.py
@@ -260,6 +260,51 @@ async def test_fetch_message_with_error__expect_matrix_error(room, client):
         await room.fetch_message("$event123")
 
 
+# SET NAME / SET TOPIC
+
+
+@pytest.mark.asyncio
+async def test_set_name__expect_room_state_updated(room, client):
+    client.room_put_state = AsyncMock()
+
+    await room.set_name("General")
+
+    client.room_put_state.assert_awaited_once_with(
+        room_id="!room:example.com",
+        event_type="m.room.name",
+        content={"name": "General"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_set_name_with_error__expect_matrix_error(room, client):
+    client.room_put_state = AsyncMock(side_effect=Exception("Insufficient permissions"))
+
+    with pytest.raises(MatrixError, match="Failed to set room name"):
+        await room.set_name("General")
+
+
+@pytest.mark.asyncio
+async def test_set_topic__expect_room_state_updated(room, client):
+    client.room_put_state = AsyncMock()
+
+    await room.set_topic("Last updated: 13:00 UTC")
+
+    client.room_put_state.assert_awaited_once_with(
+        room_id="!room:example.com",
+        event_type="m.room.topic",
+        content={"topic": "Last updated: 13:00 UTC"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_set_topic_with_error__expect_matrix_error(room, client):
+    client.room_put_state = AsyncMock(side_effect=Exception("Insufficient permissions"))
+
+    with pytest.raises(MatrixError, match="Failed to set room topic"):
+        await room.set_topic("Last updated: 13:00 UTC")
+
+
 # INVITE
 
 


### PR DESCRIPTION
Closes #69

Added \set_name(name)\ and \set_topic(topic)\ methods to \Room\. Both use \client.room_put_state()\ to update the respective state events. Includes unit tests for success and error cases for each method.