### PR TITLE
🔥 Feature: Add broadcast to bot and space

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## Description
+Brief description of what this PR does and why.
+
+### Type of Change
+- [ ] Feature
+- [ ] Refactor
+- [ ] Bug fix
+- [ ] Documentation
+- [ ] Other: ___
+
+### Pre-merge Checklist
+- [ ] Run tests: `pytest`
+- [ ] Run type check: `mypy`
+- [ ] Run formatting: `black .

--- a/matrix/bot.py
+++ b/matrix/bot.py
@@ -7,6 +7,9 @@ from typing import Optional, Any
 
 from nio import AsyncClient, Event, MatrixRoom
 
+from matrix.message import Message
+from matrix.types import File
+
 from .room import Room, make_room
 from .space import Space
 from .group import Group
@@ -423,3 +426,42 @@ class Bot(Registry):
             ctx.command = cmd
 
         return ctx
+
+    # ROOMS
+
+    async def broadcast(
+        self,
+        rooms: list[Room],
+        content: str | None = None,
+        *,
+        raw: bool = False,
+        notice: bool = False,
+        file: File | None = None,
+    ) -> list[Message]:
+        """Broadcasts a message to the specified rooms.
+
+        Supports text messages (with optional markdown formatting)
+        and file uploads (including images, videos, and audio).
+        If a space is provided, it is silently skipped.
+
+        ## Example
+
+        ```python
+        # Broadcast a markdown-formatted text message
+        await bot.broadcast([room1, room2, ...], "Hello **world**!")
+
+        # Broadcast a notice message
+        await bot.broadcast([room1, room2, ...], "Event started", notice=True)
+
+        # Broadcast a file
+        file = File(path="mxc://...", filename="document.pdf", mimetype="application/pdf")
+        await bot.broadcast([room1, room2, ...], file=file)
+
+        # Broadcast an image
+        image = Image(path="mxc://...", filename="photo.jpg", mimetype="image/jpeg", width=800, height=600)
+        await bot.broadcast([room1, room2, ...], file=image)
+        ```
+        """
+        rooms = filter(lambda child: not isinstance(child, Space), rooms)
+        async_send = [room.send(content, raw=raw, notice=notice, file=file) for room in rooms]
+        return await asyncio.gather(*async_send)

--- a/matrix/bot.py
+++ b/matrix/bot.py
@@ -462,7 +462,7 @@ class Bot(Registry):
         await bot.broadcast([room1, room2, ...], file=image)
         ```
         """
-        rooms = filter(lambda child: not isinstance(child, Space), rooms)
+        rooms = list(filter(lambda child: not isinstance(child, Space), rooms))
         async_send = [
             room.send(content, raw=raw, notice=notice, file=file) for room in rooms
         ]

--- a/matrix/bot.py
+++ b/matrix/bot.py
@@ -463,5 +463,7 @@ class Bot(Registry):
         ```
         """
         rooms = filter(lambda child: not isinstance(child, Space), rooms)
-        async_send = [room.send(content, raw=raw, notice=notice, file=file) for room in rooms]
+        async_send = [
+            room.send(content, raw=raw, notice=notice, file=file) for room in rooms
+        ]
         return await asyncio.gather(*async_send)

--- a/matrix/space.py
+++ b/matrix/space.py
@@ -55,11 +55,16 @@ class Space(Room, room_type="m.space"):
         raw: bool = False,
         notice: bool = False,
         file: File | None = None,
+        depth: int = 1
     ) -> list[Message]:
-        """Broadcasts a message to the room.
+        """Broadcasts a message to all rooms in this space.
 
         Supports text messages (with optional markdown formatting)
         and file uploads (including images, videos, and audio).
+
+        Children the bot has not joined are silently omitted. Use `depth` to
+        recursively broadcast to children of sub-spaces. `depth=1` broadcasts
+        to direct children only (default).
 
         ## Example
 
@@ -77,7 +82,11 @@ class Space(Room, room_type="m.space"):
         # Broadcast an image
         image = Image(path="mxc://...", filename="photo.jpg", mimetype="image/jpeg", width=800, height=600)
         await space.broadcast(file=image)
+
+        # Broadcast a notice message to space's rooms and the rooms of its subspaces
+        await space.broadcast("New Announcement", notice=True, depth=2)
         ```
         """
-        async_send = [room.send(content, raw=raw, notice=notice, file=file) for room in self.get_children()]
+        rooms = filter(lambda room: not isinstance(room, Space), self.get_children(depth=depth))
+        async_send = [room.send(content, raw=raw, notice=notice, file=file) for room in rooms]
         return await asyncio.gather(*async_send)

--- a/matrix/space.py
+++ b/matrix/space.py
@@ -6,6 +6,7 @@ from matrix.room import Room, make_room
 
 from matrix.types import File
 
+
 class Space(Room, room_type="m.space"):
     def get_children(self, depth: int = 1) -> list[Room | Self]:
         """Return the child rooms and spaces of this space that the bot has joined.
@@ -55,7 +56,7 @@ class Space(Room, room_type="m.space"):
         raw: bool = False,
         notice: bool = False,
         file: File | None = None,
-        depth: int = 1
+        depth: int = 1,
     ) -> list[Message]:
         """Broadcasts a message to all rooms in this space.
 
@@ -87,6 +88,10 @@ class Space(Room, room_type="m.space"):
         await space.broadcast("New Announcement", notice=True, depth=2)
         ```
         """
-        rooms = filter(lambda room: not isinstance(room, Space), self.get_children(depth=depth))
-        async_send = [room.send(content, raw=raw, notice=notice, file=file) for room in rooms]
+        rooms = filter(
+            lambda room: not isinstance(room, Space), self.get_children(depth=depth)
+        )
+        async_send = [
+            room.send(content, raw=raw, notice=notice, file=file) for room in rooms
+        ]
         return await asyncio.gather(*async_send)

--- a/matrix/space.py
+++ b/matrix/space.py
@@ -1,6 +1,10 @@
 from typing import Self
+import asyncio
+
+from matrix.message import Message
 from matrix.room import Room, make_room
 
+from matrix.types import File
 
 class Space(Room, room_type="m.space"):
     def get_children(self, depth: int = 1) -> list[Room | Self]:
@@ -43,3 +47,37 @@ class Space(Room, room_type="m.space"):
                 children.extend(child.get_children(depth - 1))
 
         return children
+
+    async def broadcast(
+        self,
+        content: str | None = None,
+        *,
+        raw: bool = False,
+        notice: bool = False,
+        file: File | None = None,
+    ) -> list[Message]:
+        """Broadcasts a message to the room.
+
+        Supports text messages (with optional markdown formatting)
+        and file uploads (including images, videos, and audio).
+
+        ## Example
+
+        ```python
+        # Broadcast a markdown-formatted text message
+        await space.broadcast("Hello **world**!")
+
+        # Broadcast a notice message
+        await space.broadcast("Event started", notice=True)
+
+        # Broadcast a file
+        file = File(path="mxc://...", filename="document.pdf", mimetype="application/pdf")
+        await space.broadcast(file=file)
+
+        # Broadcast an image
+        image = Image(path="mxc://...", filename="photo.jpg", mimetype="image/jpeg", width=800, height=600)
+        await space.broadcast(file=image)
+        ```
+        """
+        async_send = [room.send(content, raw=raw, notice=notice, file=file) for room in self.get_children()]
+        return await asyncio.gather(*async_send)

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1,9 +1,11 @@
 import pytest
 
-from unittest.mock import AsyncMock, MagicMock, patch
-from nio import MatrixRoom, RoomMessageText, LoginError
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+from nio import MatrixRoom, RoomMessageText, LoginError, Event
 
 from matrix import Bot, Config, Extension, Room, Space
+from matrix.message import Message
+from matrix.types import File
 from matrix.errors import (
     CheckError,
     CommandNotFoundError,
@@ -970,3 +972,129 @@ def test_unload_extension_removes_only_its_jobs(bot: Bot):
     job_names = [j.name for j in bot.scheduler.jobs]
 
     assert "task" in job_names
+
+
+@pytest.fixture
+def mock_send_response(bot):
+    """Set up client to return a mock event after room_send and fetch_event."""
+    send_response = Mock()
+    send_response.event_id = "$event123"
+    bot._client.room_send = AsyncMock(return_value=send_response)
+
+    mock_event = MagicMock(spec=Event)
+    mock_event.event_id = "$event123"
+
+    get_event_response = Mock()
+    get_event_response.event = mock_event
+    bot._client.room_get_event = AsyncMock(return_value=get_event_response)
+
+    return send_response
+
+
+@pytest.fixture
+def make_room(bot):
+    """Factory that creates a Room instance for a given room ID."""
+    def _make(room_id):
+        matrix_room = MatrixRoom(room_id=room_id, own_user_id="grace")
+        matrix_room.name = room_id
+        bot._client.rooms = {**bot._client.rooms, room_id: matrix_room}
+        return Room(matrix_room, bot.client)
+
+    return _make
+
+
+@pytest.mark.asyncio
+async def test_broadcast__expect_message_sent_to_all_rooms(
+    bot, make_room, mock_send_response
+):
+    room1 = make_room("!room1:example.com")
+    room2 = make_room("!room2:example.com")
+
+    results = await bot.broadcast([room1, room2], "Hello!")
+
+    assert len(results) == 2
+    assert all(isinstance(msg, Message) for msg in results)
+    assert bot._client.room_send.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_broadcast__with_empty_list__expect_no_messages(
+    bot, mock_send_response
+):
+    results = await bot.broadcast([], "Hello!")
+
+    assert results == []
+    bot._client.room_send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_broadcast__with_space_in_list__expect_space_skipped(
+    bot, make_room, mock_send_response
+):
+    room = make_room("!room:example.com")
+    space_matrix = MatrixRoom(
+        room_id="!space:example.com", own_user_id="grace"
+    )
+    space_matrix.name = "Test Space"
+    space_matrix.room_type = "m.space"
+    bot._client.rooms = {**bot._client.rooms, "!space:example.com": space_matrix}
+    space = Space(space_matrix, bot.client)
+
+    results = await bot.broadcast([room, space], "Hello!")
+
+    assert len(results) == 1
+    assert bot._client.room_send.await_count == 1
+    sent_room_ids = {
+        call.kwargs["room_id"] for call in bot._client.room_send.await_args_list
+    }
+    assert sent_room_ids == {"!room:example.com"}
+
+
+@pytest.mark.asyncio
+async def test_broadcast_raw__expect_unformatted_messages(
+    bot, make_room, mock_send_response
+):
+    room = make_room("!room:example.com")
+
+    await bot.broadcast([room], "Hello world!", raw=True)
+
+    call_args = bot._client.room_send.call_args
+    content = call_args.kwargs["content"]
+    assert content["msgtype"] == "m.text"
+    assert content["body"] == "Hello world!"
+    assert "formatted_body" not in content
+
+
+@pytest.mark.asyncio
+async def test_broadcast_notice__expect_notice_message_type(
+    bot, make_room, mock_send_response
+):
+    room = make_room("!room:example.com")
+
+    await bot.broadcast([room], "Special Event started!", notice=True)
+
+    call_args = bot._client.room_send.call_args
+    content = call_args.kwargs["content"]
+    assert content["msgtype"] == "m.notice"
+    assert content["body"] == "Special Event started!"
+
+
+@pytest.mark.asyncio
+async def test_broadcast_file__expect_file_message(
+    bot, make_room, mock_send_response
+):
+    room = make_room("!room:example.com")
+
+    file = File(
+        path="mxc://example.com/abc123",
+        filename="document.pdf",
+        mimetype="application/pdf",
+    )
+
+    await bot.broadcast([room], file=file)
+
+    call_args = bot._client.room_send.call_args
+    content = call_args.kwargs["content"]
+    assert content["msgtype"] == "m.file"
+    assert content["body"] == "document.pdf"
+    assert content["url"] == "mxc://example.com/abc123"

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -994,6 +994,7 @@ def mock_send_response(bot):
 @pytest.fixture
 def make_room(bot):
     """Factory that creates a Room instance for a given room ID."""
+
     def _make(room_id):
         matrix_room = MatrixRoom(room_id=room_id, own_user_id="grace")
         matrix_room.name = room_id
@@ -1018,9 +1019,7 @@ async def test_broadcast__expect_message_sent_to_all_rooms(
 
 
 @pytest.mark.asyncio
-async def test_broadcast__with_empty_list__expect_no_messages(
-    bot, mock_send_response
-):
+async def test_broadcast__with_empty_list__expect_no_messages(bot, mock_send_response):
     results = await bot.broadcast([], "Hello!")
 
     assert results == []
@@ -1032,9 +1031,7 @@ async def test_broadcast__with_space_in_list__expect_space_skipped(
     bot, make_room, mock_send_response
 ):
     room = make_room("!room:example.com")
-    space_matrix = MatrixRoom(
-        room_id="!space:example.com", own_user_id="grace"
-    )
+    space_matrix = MatrixRoom(room_id="!space:example.com", own_user_id="grace")
     space_matrix.name = "Test Space"
     space_matrix.room_type = "m.space"
     bot._client.rooms = {**bot._client.rooms, "!space:example.com": space_matrix}
@@ -1080,9 +1077,7 @@ async def test_broadcast_notice__expect_notice_message_type(
 
 
 @pytest.mark.asyncio
-async def test_broadcast_file__expect_file_message(
-    bot, make_room, mock_send_response
-):
+async def test_broadcast_file__expect_file_message(bot, make_room, mock_send_response):
     room = make_room("!room:example.com")
 
     file = File(

--- a/tests/test_space.py
+++ b/tests/test_space.py
@@ -1,8 +1,9 @@
 import pytest
-from unittest.mock import AsyncMock, Mock
-from nio import MatrixRoom
+from unittest.mock import AsyncMock, Mock, MagicMock
+from nio import MatrixRoom, Event
 from matrix.room import Room
 from matrix.space import Space
+from matrix.message import Message
 
 
 @pytest.fixture
@@ -21,6 +22,23 @@ def matrix_space():
 @pytest.fixture
 def space(matrix_space, client):
     return Space(matrix_space, client)
+
+
+@pytest.fixture
+def mock_send_response(client):
+    """Set up client to return a mock event after room_send and fetch_event."""
+    send_response = Mock()
+    send_response.event_id = "$event123"
+    client.room_send = AsyncMock(return_value=send_response)
+
+    mock_event = MagicMock(spec=Event)
+    mock_event.event_id = "$event123"
+
+    get_event_response = Mock()
+    get_event_response.event = mock_event
+    client.room_get_event = AsyncMock(return_value=get_event_response)
+
+    return send_response
 
 
 def test_get_children__with_room_child__expect_room_instance(
@@ -149,3 +167,136 @@ def test_get_children__with_depth_two__expect_recursive_children(
     ids = [r.room_id for r in result]
     assert "!subspace:example.com" in ids
     assert "!nested:example.com" in ids
+
+
+@pytest.mark.asyncio
+async def test_broadcast__expect_message_sent_to_all_children(
+    space, matrix_space, client, mock_send_response
+):
+    child1 = MatrixRoom(room_id="!child1:example.com", own_user_id="@bot:example.com")
+    child1.name = "Child 1"
+    child2 = MatrixRoom(room_id="!child2:example.com", own_user_id="@bot:example.com")
+    child2.name = "Child 2"
+    matrix_space.children = {"!child1:example.com", "!child2:example.com"}
+    client.rooms = {
+        "!child1:example.com": child1,
+        "!child2:example.com": child2,
+    }
+
+    results = await space.broadcast("Hello!")
+
+    assert len(results) == 2
+    assert all(isinstance(msg, Message) for msg in results)
+    assert client.room_send.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_broadcast__with_no_children__expect_empty_list(
+    space, matrix_space, client
+):
+    matrix_space.children = set()
+    client.rooms = {}
+
+    results = await space.broadcast("Hello!")
+
+    assert results == []
+    client.room_send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_broadcast__with_unjoined_children__expect_empty_list(
+    space, matrix_space, client
+):
+    matrix_space.children = {"!unknown:example.com"}
+    client.rooms = {}
+
+    results = await space.broadcast("Hello!")
+
+    assert results == []
+    client.room_send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_broadcast_raw__expect_unformatted_messages(
+    space, matrix_space, client, mock_send_response
+):
+    child = MatrixRoom(room_id="!child:example.com", own_user_id="@bot:example.com")
+    child.name = "Child"
+    matrix_space.children = {"!child:example.com"}
+    client.rooms = {"!child:example.com": child}
+
+    await space.broadcast("Hello world!", raw=True)
+
+    call_args = client.room_send.call_args
+    content = call_args.kwargs["content"]
+    assert content["msgtype"] == "m.text"
+    assert content["body"] == "Hello world!"
+    assert "formatted_body" not in content
+
+
+@pytest.mark.asyncio
+async def test_broadcast_notice__expect_notice_message_type(
+    space, matrix_space, client, mock_send_response
+):
+    child = MatrixRoom(room_id="!child:example.com", own_user_id="@bot:example.com")
+    child.name = "Child"
+    matrix_space.children = {"!child:example.com"}
+    client.rooms = {"!child:example.com": child}
+
+    await space.broadcast("Special Event started!", notice=True)
+
+    call_args = client.room_send.call_args
+    content = call_args.kwargs["content"]
+    assert content["msgtype"] == "m.notice"
+    assert content["body"] == "Special Event started!"
+
+
+@pytest.mark.asyncio
+async def test_broadcast_file__expect_file_message(
+    space, matrix_space, client, mock_send_response
+):
+    from matrix.types import File
+
+    child = MatrixRoom(room_id="!child:example.com", own_user_id="@bot:example.com")
+    child.name = "Child"
+    matrix_space.children = {"!child:example.com"}
+    client.rooms = {"!child:example.com": child}
+
+    file = File(
+        path="mxc://example.com/abc123",
+        filename="document.pdf",
+        mimetype="application/pdf",
+    )
+
+    await space.broadcast(file=file)
+
+    call_args = client.room_send.call_args
+    content = call_args.kwargs["content"]
+    assert content["msgtype"] == "m.file"
+    assert content["body"] == "document.pdf"
+    assert content["url"] == "mxc://example.com/abc123"
+
+
+@pytest.mark.asyncio
+async def test_broadcast__with_mixed_children__expect_message_to_all(
+    space, matrix_space, client, mock_send_response
+):
+    room_child = MatrixRoom(room_id="!room:example.com", own_user_id="@bot:example.com")
+    room_child.name = "Room Child"
+    space_child = MatrixRoom(room_id="!sub:example.com", own_user_id="@bot:example.com")
+    space_child.name = "Sub Space"
+    space_child.room_type = "m.space"
+    matrix_space.children = {"!room:example.com", "!sub:example.com"}
+    client.rooms = {
+        "!room:example.com": room_child,
+        "!sub:example.com": space_child,
+    }
+
+    results = await space.broadcast("Hello!")
+
+    assert len(results) == 2
+    assert client.room_send.await_count == 2
+    sent_room_ids = {
+        call.kwargs["room_id"] for call in client.room_send.await_args_list
+    }
+    assert sent_room_ids == {"!room:example.com", "!sub:example.com"}

--- a/tests/test_space.py
+++ b/tests/test_space.py
@@ -294,9 +294,144 @@ async def test_broadcast__with_mixed_children__expect_message_to_all(
 
     results = await space.broadcast("Hello!")
 
+    assert len(results) == 1
+    assert client.room_send.await_count == 1
+    sent_room_ids = {
+        call.kwargs["room_id"] for call in client.room_send.await_args_list
+    }
+    assert sent_room_ids == {"!room:example.com"}
+
+
+@pytest.mark.asyncio
+async def test_broadcast__with_mixed_children_and_nested_room__expect_only_top_level_room_at_depth_one(
+    space, matrix_space, client, mock_send_response
+):
+    room_child = MatrixRoom(room_id="!room:example.com", own_user_id="@bot:example.com")
+    room_child.name = "Room Child"
+    space_child = MatrixRoom(room_id="!sub:example.com", own_user_id="@bot:example.com")
+    space_child.name = "Sub Space"
+    space_child.room_type = "m.space"
+    nested = MatrixRoom(room_id="!nested:example.com", own_user_id="@bot:example.com")
+    nested.name = "Nested Room"
+    space_child.children = {"!nested:example.com"}
+    matrix_space.children = {"!room:example.com", "!sub:example.com"}
+    client.rooms = {
+        "!room:example.com": room_child,
+        "!sub:example.com": space_child,
+        "!nested:example.com": nested,
+    }
+
+    results = await space.broadcast("Hello!", depth=1)
+
+    assert len(results) == 1
+    assert client.room_send.await_count == 1
+    sent_room_ids = {
+        call.kwargs["room_id"] for call in client.room_send.await_args_list
+    }
+    assert sent_room_ids == {"!room:example.com"}
+
+
+@pytest.mark.asyncio
+async def test_broadcast__with_depth_two__expect_message_to_nested_children(
+    space, matrix_space, client, mock_send_response
+):
+    subspace = MatrixRoom(
+        room_id="!subspace:example.com", own_user_id="@bot:example.com"
+    )
+    subspace.name = "Sub Space"
+    subspace.room_type = "m.space"
+    nested = MatrixRoom(room_id="!nested:example.com", own_user_id="@bot:example.com")
+    nested.name = "Nested Room"
+    subspace.children = {"!nested:example.com"}
+    matrix_space.children = {"!subspace:example.com"}
+    client.rooms = {
+        "!subspace:example.com": subspace,
+        "!nested:example.com": nested,
+    }
+
+    results = await space.broadcast("Hello!", depth=2)
+
+    assert len(results) == 1
+    assert client.room_send.await_count == 1
+    sent_room_ids = {
+        call.kwargs["room_id"] for call in client.room_send.await_args_list
+    }
+    assert sent_room_ids == {"!nested:example.com"}
+
+
+@pytest.mark.asyncio
+async def test_broadcast__with_depth_two_and_top_level_room__expect_both_rooms(
+    space, matrix_space, client, mock_send_response
+):
+    room_child = MatrixRoom(room_id="!room:example.com", own_user_id="@bot:example.com")
+    room_child.name = "Room Child"
+    subspace = MatrixRoom(
+        room_id="!subspace:example.com", own_user_id="@bot:example.com"
+    )
+    subspace.name = "Sub Space"
+    subspace.room_type = "m.space"
+    nested = MatrixRoom(room_id="!nested:example.com", own_user_id="@bot:example.com")
+    nested.name = "Nested Room"
+    subspace.children = {"!nested:example.com"}
+    matrix_space.children = {"!room:example.com", "!subspace:example.com"}
+    client.rooms = {
+        "!room:example.com": room_child,
+        "!subspace:example.com": subspace,
+        "!nested:example.com": nested,
+    }
+
+    results = await space.broadcast("Hello!", depth=2)
+
     assert len(results) == 2
     assert client.room_send.await_count == 2
     sent_room_ids = {
         call.kwargs["room_id"] for call in client.room_send.await_args_list
     }
-    assert sent_room_ids == {"!room:example.com", "!sub:example.com"}
+    assert sent_room_ids == {"!room:example.com", "!nested:example.com"}
+
+
+@pytest.mark.asyncio
+async def test_broadcast__with_depth_one__expect_no_nested_children(
+    space, matrix_space, client, mock_send_response
+):
+    subspace = MatrixRoom(
+        room_id="!subspace:example.com", own_user_id="@bot:example.com"
+    )
+    subspace.name = "Sub Space"
+    subspace.room_type = "m.space"
+    nested = MatrixRoom(room_id="!nested:example.com", own_user_id="@bot:example.com")
+    nested.name = "Nested Room"
+    subspace.children = {"!nested:example.com"}
+    matrix_space.children = {"!subspace:example.com"}
+    client.rooms = {
+        "!subspace:example.com": subspace,
+        "!nested:example.com": nested,
+    }
+
+    results = await space.broadcast("Hello!", depth=1)
+
+    assert results == []
+    client.room_send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_broadcast__with_depth_zero__expect_no_messages(
+    space, matrix_space, client, mock_send_response
+):
+    child = MatrixRoom(room_id="!child:example.com", own_user_id="@bot:example.com")
+    child.name = "Child"
+    matrix_space.children = {"!child:example.com"}
+    client.rooms = {"!child:example.com": child}
+
+    results = await space.broadcast("Hello!", depth=0)
+
+    assert results == []
+    client.room_send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_broadcast__with_negative_depth__expect_value_error(
+    space, matrix_space, client
+):
+    with pytest.raises(ValueError, match="depth must be a non-negative integer"):
+        await space.broadcast("Hello!", depth=-1)


### PR DESCRIPTION
## Description

This PR adds a `broadcast` method to `matrix/bot.py` and `matrix/space.py`.

### matrix/bot.py:
```py
    async def broadcast(
        self,
        rooms: list[Room],
        content: str | None = None,
        *,
        raw: bool = False,
        notice: bool = False,
        file: File | None = None,
    ) -> list[Message]
```

Behavior: Calls `send()` on the provided list of rooms (skips over spaces).

### matrix/space.py:
```py
    async def broadcast(
        self,
        content: str | None = None,
        *,
        raw: bool = False,
        notice: bool = False,
        file: File | None = None,
        depth: int = 1
    ) -> list[Message]
```

Behavior: Calls `send()` on all child rooms of the given space up to the specified `depth` (default is `1`, which means only broadcast to immediate sub rooms).

---

Fixes: #66