### PR TITLE
Fix Error Handler

### DIFF
--- a/matrix/_error_handler.py
+++ b/matrix/_error_handler.py
@@ -1,0 +1,14 @@
+import inspect
+from typing import Callable, Dict, Optional, TypeVar
+
+F = TypeVar("F", bound=Callable[..., object])
+
+
+def resolve_error_handler(
+    handlers: Dict[type[Exception], F], error: Exception
+) -> Optional[F]:
+    """Look up the handler registered for the error's type or nearest base class."""
+    for cls in inspect.getmro(type(error)):
+        if cls in handlers:
+            return handlers[cls]
+    return None

--- a/matrix/bot.py
+++ b/matrix/bot.py
@@ -259,19 +259,23 @@ class Bot(Registry):
         """Override this in a subclass."""
         self.log.exception("Unhandled error: '%s'", error)
 
-    async def _on_command_error(self, ctx: Context, error: Exception) -> None:
+    async def _on_command_error(self, ctx: Context, error: Exception) -> bool:
         """
         Handles errors raised during command invocation.
 
         This method is called automatically when a command error occurs.
         If a specific error handler is registered for the type of the
         exception, it will be invoked with the current context and error.
+
+        Returns True if a specific handler was found and invoked, False if
+        it fell through to the default dispatch/log path.
         """
         if handler := self.resolve_handler(self._command_error_handlers, error):
             await handler(ctx, error)
-            return
+            return True
 
         await self._dispatch("on_command_error", ctx, error)
+        return False
 
     # ENTRYPOINT
 

--- a/matrix/bot.py
+++ b/matrix/bot.py
@@ -16,6 +16,7 @@ from .extension import Extension
 from .registry import Registry
 from .help import HelpCommand, DefaultHelpCommand
 from .scheduler import Scheduler
+from ._error_handler import resolve_error_handler
 from .errors import (
     AlreadyRegisteredError,
     CommandNotFoundError,
@@ -242,7 +243,7 @@ class Bot(Registry):
         self.log.exception("Unhandled error: '%s'", error)
 
     async def _on_error(self, error: Exception) -> None:
-        if handler := self.resolve_handler(self._error_handlers, error):
+        if handler := resolve_error_handler(self._error_handlers, error):
             await handler(error)
             return
 
@@ -270,7 +271,7 @@ class Bot(Registry):
         Returns True if a specific handler was found and invoked, False if
         it fell through to the default dispatch/log path.
         """
-        if handler := self.resolve_handler(self._command_error_handlers, error):
+        if handler := resolve_error_handler(self._command_error_handlers, error):
             await handler(ctx, error)
             return True
 

--- a/matrix/bot.py
+++ b/matrix/bot.py
@@ -242,7 +242,7 @@ class Bot(Registry):
         self.log.exception("Unhandled error: '%s'", error)
 
     async def _on_error(self, error: Exception) -> None:
-        if handler := self._error_handlers.get(type(error)):
+        if handler := self.resolve_handler(self._error_handlers, error):
             await handler(error)
             return
 
@@ -267,7 +267,7 @@ class Bot(Registry):
         If a specific error handler is registered for the type of the
         exception, it will be invoked with the current context and error.
         """
-        if handler := self._command_error_handlers.get(type(error)):
+        if handler := self.resolve_handler(self._command_error_handlers, error):
             await handler(ctx, error)
             return
 

--- a/matrix/command.py
+++ b/matrix/command.py
@@ -16,6 +16,7 @@ from typing import (
 )
 
 from .errors import MissingArgumentError, CheckError, CooldownError
+from ._error_handler import resolve_error_handler
 from time import monotonic
 from collections import defaultdict, deque
 
@@ -285,12 +286,7 @@ class Command:
         """
         Executes the registered error handler if present.
         """
-        handler = None
-
-        for cls in inspect.getmro(type(error)):
-            if cls in self._error_handlers:
-                handler = self._error_handlers[cls]
-                break
+        handler = resolve_error_handler(self._error_handlers, error)
 
         if handler:
             await handler(ctx, error)

--- a/matrix/command.py
+++ b/matrix/command.py
@@ -285,12 +285,18 @@ class Command:
         """
         Executes the registered error handler if present.
         """
+        handler = None
 
-        if handler := self._error_handlers.get(type(error)):
+        for cls in inspect.getmro(type(error)):
+            if cls in self._error_handlers:
+                handler = self._error_handlers[cls]
+                break
+
+        if handler:
             await handler(ctx, error)
             return
 
-        await ctx.bot.on_command_error(ctx, error)
+        await ctx.bot._on_command_error(ctx, error)
 
         if self._on_error:
             await self._on_error(ctx, error)

--- a/matrix/command.py
+++ b/matrix/command.py
@@ -296,7 +296,8 @@ class Command:
             await handler(ctx, error)
             return
 
-        await ctx.bot._on_command_error(ctx, error)
+        if await ctx.bot._on_command_error(ctx, error):
+            return
 
         if self._on_error:
             await self._on_error(ctx, error)

--- a/matrix/registry.py
+++ b/matrix/registry.py
@@ -458,13 +458,3 @@ class Registry:
         if not exception:
             exception = Exception
         self._command_error_handlers[exception] = func
-
-    @staticmethod
-    def resolve_handler(
-        handlers: Dict[type[Exception], F], error: Exception
-    ) -> Optional[F]:
-        """Look up the handler registered for the error's type or nearest base class."""
-        for cls in inspect.getmro(type(error)):
-            if cls in handlers:
-                return handlers[cls]
-        return None

--- a/matrix/registry.py
+++ b/matrix/registry.py
@@ -458,3 +458,13 @@ class Registry:
         if not exception:
             exception = Exception
         self._command_error_handlers[exception] = func
+
+    @staticmethod
+    def resolve_handler(
+        handlers: Dict[type[Exception], F], error: Exception
+    ) -> Optional[F]:
+        """Look up the handler registered for the error's type or nearest base class."""
+        for cls in inspect.getmro(type(error)):
+            if cls in handlers:
+                return handlers[cls]
+        return None

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -291,6 +291,44 @@ async def test_on_error_calls_fallback_handler(bot):
 
 
 @pytest.mark.asyncio
+async def test_on_error__with_subclass_error__expect_fallback_handler_called(bot):
+    called_with = None
+
+    @bot.error()
+    async def custom_error_handler(e):
+        nonlocal called_with
+        called_with = e
+
+    error = ValueError("subclass of Exception")
+    await bot._on_error(error)
+
+    assert called_with is error, "Fallback handler should catch Exception subclasses"
+
+
+@pytest.mark.asyncio
+async def test_on_error__with_specific_and_fallback_handlers__expect_specific_handler_called(
+    bot,
+):
+    fallback_called = False
+    specific_called = False
+
+    @bot.error()
+    async def fallback_handler(e):
+        nonlocal fallback_called
+        fallback_called = True
+
+    @bot.error(ValueError)
+    async def specific_handler(e):
+        nonlocal specific_called
+        specific_called = True
+
+    await bot._on_error(ValueError("test error"))
+
+    assert specific_called, "Specific handler should be used when available"
+    assert not fallback_called, "Fallback handler should not run when a specific one matches"
+
+
+@pytest.mark.asyncio
 async def test_on_error_logs_when_no_handler(bot):
     error = Exception("test")
 
@@ -377,6 +415,37 @@ async def test_bot_does_not_execute_command_when_global_check_fails(bot):
     assert not called
     bot._on_command_error.assert_awaited_once()
     assert isinstance(bot._on_command_error.call_args[0][1], CheckError)
+
+
+@pytest.mark.asyncio
+async def test_command_error_handler__with_error_raised_in_command_body__expect_handler_called(
+    bot,
+):
+    handled = None
+
+    @bot.error(ValueError, context=True)
+    async def on_value_error(ctx, error):
+        nonlocal handled
+        handled = error
+
+    @bot.command()
+    async def boom(ctx):
+        raise ValueError("kaboom")
+
+    event = RoomMessageText.from_dict(
+        {
+            "content": {"body": "!boom", "msgtype": "m.text"},
+            "event_id": "$ev3",
+            "origin_server_ts": 1234567890,
+            "sender": "@user:matrix.org",
+            "type": "m.room.message",
+        }
+    )
+
+    room = MatrixRoom("!roomid", "alias")
+    await bot._process_commands(room, event)
+
+    assert isinstance(handled, ValueError)
 
 
 @pytest.mark.asyncio

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -3,7 +3,7 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 from nio import MatrixRoom, RoomMessageText, LoginError
 
-from matrix import Bot, Config, Extension, Room, Space
+from matrix import Bot, Config, Context, Extension, Room, Space
 from matrix.errors import (
     CheckError,
     CommandNotFoundError,
@@ -325,7 +325,9 @@ async def test_on_error__with_specific_and_fallback_handlers__expect_specific_ha
     await bot._on_error(ValueError("test error"))
 
     assert specific_called, "Specific handler should be used when available"
-    assert not fallback_called, "Fallback handler should not run when a specific one matches"
+    assert (
+        not fallback_called
+    ), "Fallback handler should not run when a specific one matches"
 
 
 @pytest.mark.asyncio
@@ -334,6 +336,24 @@ async def test_on_error_logs_when_no_handler(bot):
 
     await bot.on_error(error)
     bot.log.exception.assert_called_once_with("Unhandled error: '%s'", error)
+
+
+@pytest.mark.asyncio
+async def test_on_command_error__with_matching_handler__expect_returns_true(bot):
+    @bot.error(ValueError, context=True)
+    async def handler(ctx, error):
+        pass
+
+    result = await bot._on_command_error(MagicMock(), ValueError("boom"))
+
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_on_command_error__with_no_matching_handler__expect_returns_false(bot):
+    result = await bot._on_command_error(MagicMock(), ValueError("boom"))
+
+    assert result is False
 
 
 @pytest.mark.asyncio
@@ -443,9 +463,12 @@ async def test_command_error_handler__with_error_raised_in_command_body__expect_
     )
 
     room = MatrixRoom("!roomid", "alias")
-    await bot._process_commands(room, event)
+
+    with patch.object(Context, "send_help", new_callable=AsyncMock) as mock_send_help:
+        await bot._process_commands(room, event)
 
     assert isinstance(handled, ValueError)
+    mock_send_help.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -472,6 +472,44 @@ async def test_command_error_handler__with_error_raised_in_command_body__expect_
 
 
 @pytest.mark.asyncio
+async def test_command_error_handler__with_extension_handler__expect_handler_called_for_command_body_error(
+    bot,
+):
+    handled = None
+
+    ext = Extension(name="errors_ext", prefix="!")
+
+    @ext.error(ValueError, context=True)
+    async def on_value_error(ctx, error):
+        nonlocal handled
+        handled = error
+
+    @ext.command()
+    async def boom(ctx):
+        raise ValueError("kaboom")
+
+    bot.load_extension(ext)
+
+    event = RoomMessageText.from_dict(
+        {
+            "content": {"body": "!boom", "msgtype": "m.text"},
+            "event_id": "$ev4",
+            "origin_server_ts": 1234567890,
+            "sender": "@user:matrix.org",
+            "type": "m.room.message",
+        }
+    )
+
+    room = MatrixRoom("!roomid", "alias")
+
+    with patch.object(Context, "send_help", new_callable=AsyncMock) as mock_send_help:
+        await bot._process_commands(room, event)
+
+    assert isinstance(handled, ValueError)
+    mock_send_help.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_command_executes(bot):
     called = False
 

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -174,6 +174,33 @@ async def test_error_handler__with_exception_subclass__expect_handler_called():
 
 
 @pytest.mark.asyncio
+async def test_error_handler__with_grandparent_exception_class__expect_handler_called():
+    class GrandparentError(Exception):
+        pass
+
+    class ParentError(GrandparentError):
+        pass
+
+    class ChildError(ParentError):
+        pass
+
+    async def failing_command(ctx):
+        raise ChildError("boom")
+
+    cmd = Command(failing_command)
+    ctx = DummyContext(args=[])
+    handled = None
+
+    @cmd.error(GrandparentError)
+    async def handler(_ctx, error):
+        nonlocal handled
+        handled = error
+
+    await cmd(ctx)
+    assert isinstance(handled, ChildError)
+
+
+@pytest.mark.asyncio
 async def test_on_error__with_bot_handler_matched__expect_no_fallback_help():
     async def failing_command(ctx):
         raise ValueError("boom")

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -10,6 +10,9 @@ class DummyBot:
     async def on_command_error(self, _ctx, _error):
         return None
 
+    async def _on_command_error(self, ctx, error):
+        return await self.on_command_error(ctx, error)
+
 
 class DummyContext:
     def __init__(self, args=None):
@@ -143,6 +146,30 @@ async def test_error_handler():
 
     await cmd(ctx)
     assert called
+
+
+@pytest.mark.asyncio
+async def test_error_handler__with_exception_subclass__expect_handler_called():
+    class BaseCustomError(Exception):
+        pass
+
+    class SubCustomError(BaseCustomError):
+        pass
+
+    async def failing_command(ctx):
+        raise SubCustomError("boom")
+
+    cmd = Command(failing_command)
+    ctx = DummyContext(args=[])
+    handled = None
+
+    @cmd.error(BaseCustomError)
+    async def handler(_ctx, error):
+        nonlocal handled
+        handled = error
+
+    await cmd(ctx)
+    assert isinstance(handled, SubCustomError)
 
 
 @pytest.mark.asyncio

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -1,7 +1,7 @@
 import pytest
 import inspect
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 from matrix.errors import MissingArgumentError
 from matrix.command import Command
 
@@ -11,7 +11,8 @@ class DummyBot:
         return None
 
     async def _on_command_error(self, ctx, error):
-        return await self.on_command_error(ctx, error)
+        await self.on_command_error(ctx, error)
+        return False
 
 
 class DummyContext:
@@ -170,6 +171,38 @@ async def test_error_handler__with_exception_subclass__expect_handler_called():
 
     await cmd(ctx)
     assert isinstance(handled, SubCustomError)
+
+
+@pytest.mark.asyncio
+async def test_on_error__with_bot_handler_matched__expect_no_fallback_help():
+    async def failing_command(ctx):
+        raise ValueError("boom")
+
+    cmd = Command(failing_command)
+    ctx = DummyContext(args=[])
+    ctx.bot._on_command_error = AsyncMock(return_value=True)
+    ctx.send_help = AsyncMock()
+
+    await cmd(ctx)
+
+    ctx.send_help.assert_not_called()
+    ctx.logger.exception.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_on_error__with_no_bot_handler_matched__expect_fallback_help():
+    async def failing_command(ctx):
+        raise ValueError("boom")
+
+    cmd = Command(failing_command)
+    ctx = DummyContext(args=[])
+    ctx.bot._on_command_error = AsyncMock(return_value=False)
+    ctx.send_help = AsyncMock()
+
+    await cmd(ctx)
+
+    ctx.send_help.assert_awaited_once()
+    ctx.logger.exception.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/tests/test_error_handler.py
+++ b/tests/test_error_handler.py
@@ -1,0 +1,74 @@
+from matrix._error_handler import resolve_error_handler
+
+
+def test_resolve_error_handler_with_exact_type_match__expect_handler_returned():
+    def handler(error):
+        pass
+
+    handlers = {ValueError: handler}
+
+    assert resolve_error_handler(handlers, ValueError("boom")) is handler
+
+
+def test_resolve_error_handler_with_exception_subclass__expect_base_handler_returned():
+    class BaseCustomError(Exception):
+        pass
+
+    class SubCustomError(BaseCustomError):
+        pass
+
+    def handler(error):
+        pass
+
+    handlers = {BaseCustomError: handler}
+
+    assert resolve_error_handler(handlers, SubCustomError("boom")) is handler
+
+
+def test_resolve_error_handler_with_grandparent_exception_class__expect_handler_returned():
+    class GrandparentError(Exception):
+        pass
+
+    class ParentError(GrandparentError):
+        pass
+
+    class ChildError(ParentError):
+        pass
+
+    def handler(error):
+        pass
+
+    handlers = {GrandparentError: handler}
+
+    assert resolve_error_handler(handlers, ChildError("boom")) is handler
+
+
+def test_resolve_error_handler_with_no_matching_handler__expect_none_returned():
+    def handler(error):
+        pass
+
+    handlers = {ValueError: handler}
+
+    assert resolve_error_handler(handlers, TypeError("boom")) is None
+
+
+def test_resolve_error_handler_with_empty_handlers__expect_none_returned():
+    assert resolve_error_handler({}, ValueError("boom")) is None
+
+
+def test_resolve_error_handler_with_specific_and_base_registered__expect_specific_handler_returned():
+    class BaseCustomError(Exception):
+        pass
+
+    class SubCustomError(BaseCustomError):
+        pass
+
+    def base_handler(error):
+        pass
+
+    def specific_handler(error):
+        pass
+
+    handlers = {BaseCustomError: base_handler, SubCustomError: specific_handler}
+
+    assert resolve_error_handler(handlers, SubCustomError("boom")) is specific_handler

--- a/tests/test_error_handler.py
+++ b/tests/test_error_handler.py
@@ -1,6 +1,14 @@
 from matrix._error_handler import resolve_error_handler
 
 
+class BaseCustomError(Exception):
+    pass
+
+
+class SubCustomError(BaseCustomError):
+    pass
+
+
 def test_resolve_error_handler_with_exact_type_match__expect_handler_returned():
     def handler(error):
         pass
@@ -11,12 +19,6 @@ def test_resolve_error_handler_with_exact_type_match__expect_handler_returned():
 
 
 def test_resolve_error_handler_with_exception_subclass__expect_base_handler_returned():
-    class BaseCustomError(Exception):
-        pass
-
-    class SubCustomError(BaseCustomError):
-        pass
-
     def handler(error):
         pass
 
@@ -57,12 +59,6 @@ def test_resolve_error_handler_with_empty_handlers__expect_none_returned():
 
 
 def test_resolve_error_handler_with_specific_and_base_registered__expect_specific_handler_returned():
-    class BaseCustomError(Exception):
-        pass
-
-    class SubCustomError(BaseCustomError):
-        pass
-
     def base_handler(error):
         pass
 


### PR DESCRIPTION
## Description
Error handlers (`@bot.error`, `@ext.error`, `@cmd.error`) only matched the exact exception type, so handlers registered for a base class (or the default `@bot.error()` fallback) silently never fired for subclasses. Extension/bot-level command error
handlers also never ran for exceptions raised inside a command body. 

Additionally, once an error was handled, the command would still send a generic "usage: ..." message and log it as unhandled.

This PR:
- Matches errors by walking the exception's MRO instead of exact-type lookup
- Stops double-handling


### Type of Change
- [ ] Feature
- [X] Refactor
- [x] Bug fix
- [ ] Documentation
- [ ] Other: ___

### Pre-merge Checklist
- [X] Run tests: `pytest`
- [X] Run type check: `mypy`
- [X] Run formatting: `black .
