### PR TITLE
Ci/always run all tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install .[dev]
+          pip install -e .[dev]
       - name: Lint with Black
         id: black
         continue-on-error: true
@@ -38,7 +38,7 @@ jobs:
         id: pytest
         continue-on-error: true
         run: |
-          pytest -v
+          pytest -v --cov=matrix --cov-report=term-missing --cov-fail-under=90
       - name: All checks succeeded
         if: steps.black.outcome == 'failure' || steps.mypy.outcome == 'failure' || steps.pytest.outcome == 'failure'
         run: exit 1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,11 +25,20 @@ jobs:
           python -m pip install --upgrade pip
           pip install .[dev]
       - name: Lint with Black
+        id: black
+        continue-on-error: true
         run: |
           black --check matrix/ tests/ examples/
       - name: Check typing with mypy
+        id: mypy
+        continue-on-error: true
         run: |
           mypy matrix
       - name: Test with pytest
+        id: pytest
+        continue-on-error: true
         run: |
           pytest -v
+      - name: All checks succeeded
+        if: steps.black.outcome == 'failure' || steps.mypy.outcome == 'failure' || steps.pytest.outcome == 'failure'
+        run: exit 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "pytest==9.1.1",
+    "pytest-cov==7.1.0",
     "pytest-asyncio==1.4.0",
     "black==26.5.1",
     "mypy==2.1.0",


### PR DESCRIPTION
## Description
- Lint, type-check, and pytest now all run independently via `continue-on-error: true`, so a failure in one no longer skips the others. This will improve visibility in the CI (ex. if both formatting and tests fails we can see it)
- Added `pytest-cov` and set `--cov-fail-under=90` on the `pytest` step, so the build fails if test coverage drops below 90%. This is to ensure we don't forget too many tests and keep our coverage high. 

### Type of Change
- [ ] Feature
- [ ] Refactor
- [ ] Bug fix
- [ ] Documentation
- [X] Other: Improved CI

### Pre-merge Checklist
- [X] Run tests: `pytest`
- [X] Run type check: `mypy`
- [X] Run formatting: `black .
